### PR TITLE
Ruff simplify fixes

### DIFF
--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -148,11 +148,7 @@ class DownloadCounter:
         }
 
     def has_downloads(self):
-        for v in self.as_dict().values():
-            if v > 0:
-                return True
-
-        return False
+        return any(v > 0 for v in self.as_dict().values())
 
 
 counter = DownloadCounter()
@@ -367,10 +363,7 @@ async def download_aaxc(
         if is_aycl:
             counter.count_aycl_voucher()
 
-    if codec.lower() == "mpeg":
-        ext = "mp3"
-    else:
-        ext = "aaxc"
+    ext = "mp3" if codec.lower() == "mpeg" else "aaxc"
 
     filepath = pathlib.Path(output_dir) / f"{base_filename}-{codec}.{ext}"
     lr_file = filepath.with_suffix(".voucher")

--- a/src/audible_cli/cmds/cmd_wishlist.py
+++ b/src/audible_cli/cmds/cmd_wishlist.py
@@ -114,10 +114,7 @@ async def export_wishlist(client, **params):
     prepared_wishlist.sort(key=lambda x: x["asin"])
 
     if output_format in ("tsv", "csv"):
-        if output_format == "csv":
-            dialect = "excel"
-        else:
-            dialect = "excel-tab"
+        dialect = "excel" if output_format == "csv" else "excel-tab"
 
         headers = (
             "asin",

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -121,7 +121,7 @@ class BaseItem:
             return f"https://www.audible.{domain}/companion-file/{self.asin}"
 
     def is_parent_podcast(self):
-        if (
+        return bool(
             "content_delivery_type" in self
             and "content_type" in self
             and (
@@ -129,8 +129,7 @@ class BaseItem:
                 or self.content_type == "Podcast"
             )
             and self.has_children
-        ):
-            return True
+        )
 
     def is_published(self):
         if self.publication_datetime is not None:

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -121,12 +121,16 @@ class BaseItem:
             return f"https://www.audible.{domain}/companion-file/{self.asin}"
 
     def is_parent_podcast(self):
-        if "content_delivery_type" in self and "content_type" in self:
-            if (
+        if (
+            "content_delivery_type" in self
+            and "content_type" in self
+            and (
                 self.content_delivery_type in ("Periodical", "PodcastParent")
                 or self.content_type == "Podcast"
-            ) and self.has_children:
-                return True
+            )
+            and self.has_children
+        ):
+            return True
 
     def is_published(self):
         if self.publication_datetime is not None:
@@ -217,13 +221,10 @@ class LibraryItem(BaseItem):
             self.is_parent_podcast()
             and "episode_count" in self
             and self.episode_count is not None
-        ):
-            if int(self.episode_count) != len(children):
-                if "response_groups" in request_params:
-                    request_params.pop("response_groups")
-                children = await Catalog.from_api(
-                    api_client=self._client, **request_params
-                )
+        ) and int(self.episode_count) != len(children):
+            if "response_groups" in request_params:
+                request_params.pop("response_groups")
+            children = await Catalog.from_api(api_client=self._client, **request_params)
 
         for child in children:
             child._parent = self
@@ -436,7 +437,7 @@ class BaseList:
             return None
 
     def has_asin(self, asin):
-        return True if self.get_item_by_asin(asin) else False
+        return bool(self.get_item_by_asin(asin))
 
     def search_item_by_title(self, search_title, p=80):
         match = []


### PR DESCRIPTION
% `ruff --select=SIM --fix .`
```
src/audible_cli/cmds/cmd_download.py:151:9: SIM110 [*] Use `return any(v > 0 for v in self.as_dict().values())` instead of `for` loop
src/audible_cli/cmds/cmd_download.py:370:5: SIM108 [*] Use ternary operator `ext = "mp3" if codec.lower() == "mpeg" else "aaxc"` instead of `if`-`else`-block
src/audible_cli/cmds/cmd_wishlist.py:117:9: SIM108 [*] Use ternary operator `dialect = "excel" if output_format == "csv" else "excel-tab"` instead of `if`-`else`-block
src/audible_cli/models.py:124:9: SIM102 [*] Use a single `if` statement instead of nested `if` statements
src/audible_cli/models.py:216:9: SIM102 [*] Use a single `if` statement instead of nested `if` statements
src/audible_cli/models.py:439:16: SIM210 [*] Use `bool(self.get_item_by_asin(asin))` instead of `True if self.get_item_by_asin(asin) else False`
src/audible_cli/utils.py:229:9: SIM102 [*] Use a single `if` statement instead of nested `if` statements
```
