### PR TITLE
mypy: Temporarily disable mypy error codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,12 +87,24 @@ exclude_lines = [
 ]
 
 [tool.mypy]
-strict = true
-warn_unreachable = true
+disable_error_code = [
+    "assignment",
+    "call-overload",
+    "dict-item",
+    "import",
+    "no-any-return",
+    "no-untyped-call",
+    "no-untyped-def",
+    "return-value",
+    "type-arg",
+    "union-attr",
+]
 pretty = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
+strict = true
+warn_unreachable = true
 
 [tool.ruff]
 #  missing rst-docstrings check, these should be adding through ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,16 +88,24 @@ exclude_lines = [
 
 [tool.mypy]
 disable_error_code = [
+    "arg-type",
     "assignment",
+    "attr-defined",
     "call-overload",
     "dict-item",
+    "func-returns-value",
+    "has-type",
     "import",
+    "index",
     "no-any-return",
     "no-untyped-call",
     "no-untyped-def",
+    "operator",
     "return-value",
     "type-arg",
     "union-attr",
+    "valid-type",
+    "var-annotated",
 ]
 pretty = true
 show_column_numbers = true


### PR DESCRIPTION
This makes it easier to fix errors in small groups.

Some fixes can be done via `ruff --select=ANN --fix .`
```
 21	ANN204 	[*] Missing return type annotation for special method `__init__`
```
* https://beta.ruff.rs/docs/rules/#flake8-annotations-ann